### PR TITLE
Fix key and wording

### DIFF
--- a/locale/es-es/volume.current.dialog
+++ b/locale/es-es/volume.current.dialog
@@ -1,3 +1,3 @@
 # auto translated from en-us to es-es
-El volumen está fijado para {volumen}
+El volumen está fijado en {volume}
 El volumen está en {volume}


### PR DESCRIPTION
Fix {volumen} key to {volume}

Besides, use proper preposition