### PR TITLE
fix:long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def find_resource_files():
     return package_data
 
 
-with open("README.md", "r") as f:
+with open(path.join(path.abspath(path.dirname(__file__)), "README.md"), "r") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
semver automations fail if dont use full path for README